### PR TITLE
add recommended extension for svelte sample

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "svelte.svelte-vscode"
+    ]
+}


### PR DESCRIPTION
Add `svelte.svelte-vscode` vscode extension into the recommendations list

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 03 25-13_20_10](https://github.com/devfile-samples/devfile-stack-nodejs-svelte/assets/1271546/b816ab09-06a8-4147-93f6-0b7d20c3eccc)
